### PR TITLE
fix (国际化报错): moment版本将至在2.24.0,请重新yarn一下

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "lodash": "^4.17.11",
     "lodash-decorators": "^6.0.0",
     "lodash.isequal": "^4.5.0",
-    "moment": "^2.24.0",
+    "moment": "2.24.0",
     "numeral": "^2.0.6",
     "nzh": "^1.0.3",
     "omit.js": "^1.0.2",
@@ -147,5 +147,8 @@
     "src/**/*.less",
     "config/**/*.js*",
     "scripts/**/*.js"
-  ]
+  ],
+  "resolutions": {
+    "moment": "2.24.0"
+  }
 }


### PR DESCRIPTION
在package.json加入resolution，限制ant-design pro的moment版本